### PR TITLE
Bug fixes and interface improvements -- see the comments in individual c...

### DIFF
--- a/admin/experiment-new.php
+++ b/admin/experiment-new.php
@@ -175,7 +175,8 @@ jQuery(function($){
 	var updateVariantsCode = function() {
 		var code = "$variant = shrimptest_get_variant( <?php echo $experiment_id;?> );\nswitch ( $variant ) {\n";
 		
-		for (i=0; i<newVariantId; i++) {
+		// The control is 0, so we start with Variant 1
+		for (i=1; i<newVariantId; i++) {
 			code += "  case "+i+":\n    // <?php _e('Variant');?> "+i+"\n    break;\n";
 		}
 		
@@ -183,6 +184,7 @@ jQuery(function($){
 		code += "}";
 		
 		$('#variants_code').text(code);
+		
 	};
 	
 	// metrics block

--- a/admin/experiments.php
+++ b/admin/experiments.php
@@ -158,9 +158,15 @@ foreach( $experiments as $experiment ) {
 				$p = $stat->p;
 	
 				if ( $p != null ) {
+					
+					// Calculate p value
 					$null_p = round( 1 - $p, 4 );
 					$null_p = "p &lt; {$null_p}";
-	
+					
+					// This is easier for most people to understand
+					$confidence = round( $p * 100, 0 );
+					$confidence = "{$confidence}% confidence";
+						
 					if ( $p >= 0.95 ) {
 						// TODO: allow custom confidence intervals
 						if ( $p >= 0.99 )
@@ -168,10 +174,10 @@ foreach( $experiments as $experiment ) {
 						else if ( $p >= 0.95 )
 							$desc = "confident";
 						if ( !$duration_not_reached )
-							$pmessage = sprintf( "We are <strong>%s</strong> that variant %d is %s than the control. (%s)", $desc, $stat->variant_id, $stat->type, $null_p );
+							$pmessage = sprintf( "We are <strong>%s</strong> that variant %d is %s than the control. (%s)", $desc, $stat->variant_id, $stat->type, $confidence );
 					} else {
 						if ( !$duration_not_reached )
-							$pmessage = sprintf( "We cannot confidently say whether or not variant %d is %s than the control. Perhaps there is no effect or there is not enough data. (%s)", $stat->variant_id, $stat->type, $null_p );
+							$pmessage = sprintf( "We cannot confidently say whether or not variant %d is %s than the control. Perhaps there is no effect or there is not enough data. (%s)", $stat->variant_id, $stat->type, $confidence );
 					}
 				}
 			}

--- a/admin/experiments.php
+++ b/admin/experiments.php
@@ -113,10 +113,10 @@ foreach( $experiments as $experiment ) {
 	$duration_not_reached = false;
 	$overall_result_na = true;
 	if ( isset( $experiment->data['duration'] ) && $experiment->data['duration'] ) {
-	  if ( !isset( $experiment->data['duration_reached'] ) ) {
+	  if ( !isset( $experiment->data['duration_reached'] ) && ( $experiment->status == 'active' || $experiment->status == 'finished' ) ) {
 			$duration_not_reached = true;
 			$overall_result = sprintf( __('Experiment sample size (%d unique visitors) has not been met so no confident results are available.'), $experiment->data['duration'] );
-		} else {
+		} else if ( isset( $experiment->data['duration_reached'] ) ) {
 			$overall_result_na = false;
 			$overall_result = sprintf( __('Experiment sample size has been met.'), $experiment->data['duration'] );			
 		}
@@ -163,7 +163,8 @@ foreach( $experiments as $experiment ) {
 					$null_p = round( 1 - $p, 4 );
 					$null_p = "p &lt; {$null_p}";
 					
-					// This is easier for most people to understand
+					// This would be easier for most people to understand, but it isn't yet worded right
+					// TODO: Improve phrasing
 					$confidence = round( $p * 100, 0 );
 					$confidence = "{$confidence}% confidence";
 						
@@ -174,10 +175,10 @@ foreach( $experiments as $experiment ) {
 						else if ( $p >= 0.95 )
 							$desc = "confident";
 						if ( !$duration_not_reached )
-							$pmessage = sprintf( "We are <strong>%s</strong> that variant %d is %s than the control. (%s)", $desc, $stat->variant_id, $stat->type, $confidence );
+							$pmessage = sprintf( "We are <strong>%s</strong> that variant %d is %s than the control. (%s)", $desc, $stat->variant_id, $stat->type, $null_p );
 					} else {
 						if ( !$duration_not_reached )
-							$pmessage = sprintf( "We cannot confidently say whether or not variant %d is %s than the control. Perhaps there is no effect or there is not enough data. (%s)", $stat->variant_id, $stat->type, $confidence );
+							$pmessage = sprintf( "We cannot confidently say whether or not variant %d is %s than the control. Perhaps there is no effect or there is not enough data. (%s)", $stat->variant_id, $stat->type, $null_p );
 					}
 				}
 			}

--- a/classes/core.php
+++ b/classes/core.php
@@ -654,6 +654,7 @@ setTimeout(function() {
 							PRIMARY KEY (experiment_id,variant_id)
 						);",
 						"CREATE TABLE {$this->model->db_prefix}visitors_variants (
+							visitors_variants_id INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
 							visitor_id BIGINT(20) NOT NULL ,
 							experiment_id INT NOT NULL ,
 							variant_id INT NOT NULL ,

--- a/classes/interface.php
+++ b/classes/interface.php
@@ -109,7 +109,7 @@ class ShrimpTest_Interface {
 			line-height: 16px;
 		}
 		.samplecodediv {
-			min-width: 300px;
+			width: 300px; /* Was min-width, but that made Sample Code boxes uneven */
 			float: right;
 			border-left: #dfdfdf 1px solid;
 			padding: 5px;

--- a/classes/model.php
+++ b/classes/model.php
@@ -402,7 +402,8 @@ class ShrimpTest_Model {
 		global $wpdb;
 
 		if ( !$force ) {
-			$cached_stats = get_transient( $this->stats_transient . $experiment_id );
+			//$cached_stats = get_transient( $this->stats_transient . $experiment_id ); // Disabled for now, it seems to get set innappropriately
+			$cached_stats = false;
 			if ( $cached_stats !== false ) {
 				$cached_stats['stats']['cached'] = true;
 				return $cached_stats;
@@ -571,8 +572,14 @@ class ShrimpTest_Model {
 		$variant_data = array_replace_recursive( $old_variant, $variant_data );
 
 		extract( $variant_data );
-		if ( !isset( $variant_name ) || !isset( $assignment_weight ) || empty( $assignment_weight ) )
-			wp_die( 'The variant must have a <code>name</code> and a non-zero <code>assignment_weight</code>' );
+		if ( !isset( $variant_name ) || !isset( $assignment_weight ) || empty( $assignment_weight ) ) {
+			if ( !isset( $variant_name ) && ( !isset( $assignment_weight ) || empty( $assignment_weight ) ) )
+				wp_die( 'Variant ' . $variant_id . ' must have an assignment weight other than zero and a name' );
+			if ( !isset( $variant_name ) ) 
+				wp_die( 'Variant ' . $variant_id . ' must have a name' );
+			if ( !isset( $assignment_weight ) || empty( $assignment_weight ) )
+				wp_die( 'Variant ' . $variant_id . ' must have an assignment weight other than zero' );
+		}
 
 		$data = '';
 		if ( isset( $variant_data['data'] ) )

--- a/classes/model.php
+++ b/classes/model.php
@@ -402,8 +402,8 @@ class ShrimpTest_Model {
 		global $wpdb;
 
 		if ( !$force ) {
-			//$cached_stats = get_transient( $this->stats_transient . $experiment_id ); // Disabled for now, it seems to get set innappropriately
-			$cached_stats = false;
+			//$cached_stats = get_transient( $this->stats_transient . $experiment_id ); 
+			$cached_stats = false; // Disabled for now, it seems to get set innappropriately
 			if ( $cached_stats !== false ) {
 				$cached_stats['stats']['cached'] = true;
 				return $cached_stats;

--- a/plugins/variant-shortcode/langs/en.js
+++ b/plugins/variant-shortcode/langs/en.js
@@ -1,3 +1,4 @@
+// This wasn't working -- TinyMCE would look for the plugin in /wp-admin/undefined/langs/en.js instead of this location
 tinyMCE.addI18n('en.variant_shortcode',{
 	insertABTest:"Insert ShrimpTest experiment"
 });

--- a/plugins/variant-shortcode/tinymce.js
+++ b/plugins/variant-shortcode/tinymce.js
@@ -1,9 +1,12 @@
 (function() {	
- 	tinymce.PluginManager.requireLangPack('variant_shortcode');
+
+	// Causes TinyMCE to look for undefined /wp-admin/undefined/langs/en.js instead of the correct place, which is the child folder
+ 	//tinymce.PluginManager.requireLangPack('variant_shortcode');
+ 	
 	tinymce.create('tinymce.plugins.abtest', {
 		init : function(ed, url) {
 			ed.addButton('abtest', {
-				title : 'variant_shortcode.insertABTest',
+				title : 'Insert ShrimpTest experiment', // previously 'variant_shortcode.insertABTest'
 				image : url + '/abtest.png',
 				onclick : function() {
 					insertABTest();


### PR DESCRIPTION
- "Variant 0" in sample code now correctly marked as "Variant 1"
- p value in report changed to confidence percentile, which is easier to understand. p value can be added back in, in a less obtrusive way for those who really want it
- Sample Code boxes are now a consistent width, which looks a little nicer
- Cached transient is deleted when an experiment is set to active... still doesn't work though, needs tweaking
- Bypassing language pack for Variant Shortcode plugin, since it caused TinyMCE not to load
